### PR TITLE
[semver:patch] Update get-pip url

### DIFF
--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -15,7 +15,7 @@ SetupPipx() {
         echo "pip not found"
         $SUDO apt-get update
         $SUDO apt-get install python3-setuptools
-        curl https://bootstrap.pypa.io/3.5/get-pip.py | python3
+        curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3
     fi
     # install venv with system for pipx
     # by using pipx we dont have to worry about activating the virtualenv before using eb


### PR DESCRIPTION
Fixes error shown during installation:

> Hi there!
> 
> The URL you are using to fetch this script has changed, and this one will no
> longer work. Please use get-pip.py from the following URL instead:
> 
>     https://bootstrap.pypa.io/pip/3.5/get-pip.py
> 
> Sorry if this change causes any inconvenience for you!
> 
> We don't have a good mechanism to make more gradual changes here, and this
> renaming is a part of an effort to make it easier to us to update these
> scripts, when there's a pip release. It's also essential for improving how we
> handle the `get-pip.py` scripts, when pip drops support for a Python minor
> version.
> 
> There are no more renames/URL changes planned, and we don't expect that a need
> would arise to do this again in the near future.
> 
> Thanks for understanding!
> 
> - Pradyun, on behalf of the volunteers who maintain pip.