### PR TITLE
Fix/add ebcli version parameter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,15 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      #- orb-tools/publish:
-      #    orb-name: circleci/aws-elastic-beanstalk
-      #    vcs-type: << pipeline.project.type >>
-      #    requires:
-      #      [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-      #    context: orb-publisher
-      #    filters: *filters
+      - orb-tools/publish:
+          orb-name: circleci/aws-elastic-beanstalk
+          vcs-type: << pipeline.project.type >>
+          requires:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+          context: orb-publisher
+          filters: *filters
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
-      #    requires: [orb-tools/publish]
+          requires: [orb-tools/publish]
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,15 +19,15 @@ workflows:
           filters: *filters
       - shellcheck/check:
           filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/aws-elastic-beanstalk
-          vcs-type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          context: orb-publisher
-          filters: *filters
+      #- orb-tools/publish:
+      #    orb-name: circleci/aws-elastic-beanstalk
+      #    vcs-type: << pipeline.project.type >>
+      #    requires:
+      #      [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+      #    context: orb-publisher
+      #    filters: *filters
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+      #    requires: [orb-tools/publish]
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -21,8 +21,8 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
-      - aws-cli/setup:
-          role-arn: arn:aws:iam::122211685980:role/CPE_ELASTIC_BEANSTALK_TEST
+      #- aws-cli/setup:
+      #    role-arn: arn:aws:iam::122211685980:role/CPE_ELASTIC_BEANSTALK_TEST
       - aws-elastic-beanstalk/setup
       - run:
           name: Verify EB install

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -33,19 +33,23 @@ jobs:
           environment:
             EBCLI_INPUT_VERSION: << parameters.cli-version >> 
           command: |
+            # To prevent confusion when the string is empty
+            if [ -z "$EBCLI_INPUT_VERSION" ]; then
+              EBCLI_INPUT_READABLE_VERSION="latest"
+            fi
             echo "Checking CLI version..."
             EBCLI_VERSION=$(eb --version | awk '{print $3}')
             # Uses python to isolate the latest ebcli version number from the pypi json.
             EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")""
             echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
-            echo "Expected CLI version: $EBCLI_INPUT_VERSION"
+            echo "Expected CLI version: $EBCLI_INPUT_READABLE_VERSION"
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"
 
             # Checks if the installed version matches the expected version
             if [ -n "$EBCLI_VERSION" ] && [ -n "$EBCLI_INPUT_VERSION" ] && [ -n "$EBCLI_LATEST_VERSION" ]; then
               if [ "$EBCLI_VERSION" == "$EBCLI_INPUT_VERSION" ]; then
                 echo "CLI version matches expected version."
-              elsif [ "$EBCLI_VERSION" == "$EBCLI_LATEST_VERSION" ]; then
+              elif [ "$EBCLI_VERSION" == "$EBCLI_LATEST_VERSION" ]; then
                 echo "CLI version matches the expected latest version."
               else
                 echo "Error: CLI version does not match expected version." >&2

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,8 +23,8 @@ jobs:
       EBCLI_INPUT_VERSION: << parameters.cli-version >>
     steps:
       - checkout
-      #- aws-cli/setup:
-      #    role-arn: arn:aws:iam::122211685980:role/CPE_ELASTIC_BEANSTALK_TEST
+      - aws-cli/setup:
+          role-arn: arn:aws:iam::122211685980:role/CPE_ELASTIC_BEANSTALK_TEST
       - aws-elastic-beanstalk/setup
       - run:
           name: Verify EB install
@@ -33,14 +33,16 @@ jobs:
       - run:
           name: Test app version
           command: |
-            echo "Checking CLI version..."
+            echo "Checking CLI versions..."
+            # Extracts the version number from the eb --version output
             EBCLI_VERSION=$(eb --version | awk '{print $3}')
             # Uses python to isolate the latest ebcli version number from the pypi json.
             EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")""
-            # To prevent confusion when the string is empty, set to latest version
+            # To prevent confusion when the string is empty (due to default), set input version to latest version
             if [ -z "$EBCLI_INPUT_VERSION" ]; then
               EBCLI_INPUT_VERSION="$EBCLI_LATEST_VERSION"
             fi
+            # Prints the version numbers to the console
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"
             echo "Expected CLI version: $EBCLI_INPUT_VERSION"
             echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
@@ -54,7 +56,7 @@ jobs:
                 exit 1
               fi
             else
-              # This error is thrown when either of the above version numbers don't get properly set
+              # This error is thrown when either of the above version envs don't get properly set
               echo "Error: Something went wrong with the EB installation. Unable to acquire version(s)." >&2
               exit 1
             fi
@@ -81,7 +83,7 @@ workflows:
           matrix:
               parameters:
                 executor: [python, base]
-                # Emtpy string will use latest version, otherwise testing random recent specific versions
+                # Emtpy string will use latest version, otherwise testing random recent versions
                 cli-version: ["", "3.20.5", "3.20.3", "3.20.2", "3.20.0"]
           filters: *filters
       - integration-test-deploy-setup:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -33,16 +33,16 @@ jobs:
           environment:
             EBCLI_INPUT_VERSION: << parameters.cli-version >> 
           command: |
-            # To prevent confusion when the string is empty
-            if [ -z "$EBCLI_INPUT_VERSION" ]; then
-              EBCLI_INPUT_READABLE_VERSION="latest"
-            fi
             echo "Checking CLI version..."
             EBCLI_VERSION=$(eb --version | awk '{print $3}')
             # Uses python to isolate the latest ebcli version number from the pypi json.
             EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")""
+            # To prevent confusion when the string is empty, set to latest version
+            if [ -z "$EBCLI_INPUT_VERSION" ]; then
+              EBCLI_INPUT_VERSION="$EBCLI_LATEST_VERSION"
+            fi
             echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
-            echo "Expected CLI version: $EBCLI_INPUT_READABLE_VERSION"
+            echo "Expected CLI version: $EBCLI_INPUT_VERSION"
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"
 
             # Checks if the installed version matches the expected version

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -15,6 +15,9 @@ jobs:
       executor:
         type: executor
         default:
+      cli-version:
+        type: string
+        default:
     executor: <<parameters.executor>>
     steps:
       - checkout
@@ -25,6 +28,34 @@ jobs:
           name: Verify EB install
           command: |
             command -v eb >/dev/null 2>&1 || { echo >&2 "EB cli failed to install or persist to the path"; exit 1; }
+      - run:
+          name: Test app version
+          environment:
+            EBCLI_INPUT_VERSION: << parameters.cli-version >> 
+          command: |
+            echo "Checking CLI version..."
+            EBCLI_VERSION=$(eb --version)
+            # Uses python to isolate the latest ebcli version number from the pypi json.
+            EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")"
+            echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
+            echo "Expected CLI version: $EBCLI_INPUT_VERSION"
+            echo "Latest CLI version: $EBCLI_LATEST_VERSION"
+
+            # Checks if the installed version matches the expected version
+            if [ ! -z "$EBCLI_VERSION" ] && [ ! -z "$EBCLI_INPUT_VERSION" ] && [ ! -z "$EBCLI_LATEST_VERSION" ]; then
+              if [ "$EBCLI_VERSION" == "$EBCLI_INPUT_VERSION" ]; then
+                echo "CLI version matches expected version."
+              elsif [ "$EBCLI_VERSION" == "$EBCLI_LATEST_VERSION" ]; then
+                echo "CLI version matches the expected latest version."
+              else
+                echo "Error: CLI version does not match expected version." >&2
+                exit 1
+              fi
+            else
+              # This error is thrown when either of the above version numbers don't get properly set
+              echo "Error: Something went wrong with the EB installation. Unable to acquire version(s)." >&2
+              exit 1
+            fi
   integration-test-deploy-setup:
     docker:
       - image: cimg/base:current
@@ -48,6 +79,8 @@ workflows:
           matrix:
               parameters:
                 executor: [python, base]
+                # Emtpy string will use latest version, otherwise testing random recent specific versions
+                cli-version: ["", "3.20.5", "3.20.4", "3.20.3"]
           filters: *filters
       - integration-test-deploy-setup:
           context: [CPE-OIDC]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,7 +17,7 @@ jobs:
         default:
       cli-version:
         type: string
-        default: << parameters.cli-version >>
+        default:
     executor: << parameters.executor >>
     steps:
       - checkout
@@ -30,9 +30,11 @@ jobs:
             command -v eb >/dev/null 2>&1 || { echo >&2 "EB cli failed to install or persist to the path"; exit 1; }
       - run:
           name: Test app version
+          environment:
+            EBCLI_INPUT_VERSION: << parameters.cli-version >> 
           command: |
             echo "Checking CLI version..."
-            EBCLI_VERSION=$(EB_CLI_VERSION=$(eb --version | awk '{print $3}'))
+            EBCLI_VERSION=$(eb --version | awk '{print $3}')
             # Uses python to isolate the latest ebcli version number from the pypi json.
             EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")""
             echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,6 +19,8 @@ jobs:
         type: string
         default:
     executor: << parameters.executor >>
+    environment:
+      EBCLI_INPUT_VERSION: << parameters.cli-version >>
     steps:
       - checkout
       #- aws-cli/setup:
@@ -30,8 +32,6 @@ jobs:
             command -v eb >/dev/null 2>&1 || { echo >&2 "EB cli failed to install or persist to the path"; exit 1; }
       - run:
           name: Test app version
-          environment:
-            EBCLI_INPUT_VERSION: << parameters.cli-version >> 
           command: |
             echo "Checking CLI version..."
             EBCLI_VERSION=$(eb --version | awk '{print $3}')
@@ -41,9 +41,9 @@ jobs:
             if [ -z "$EBCLI_INPUT_VERSION" ]; then
               EBCLI_INPUT_VERSION="$EBCLI_LATEST_VERSION"
             fi
-            echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
-            echo "Expected CLI version: $EBCLI_INPUT_VERSION"
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"
+            echo "Expected CLI version: $EBCLI_INPUT_VERSION"
+            echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
 
             # Checks if the installed version matches the expected version
             if [ -n "$EBCLI_VERSION" ] && [ -n "$EBCLI_INPUT_VERSION" ] && [ -n "$EBCLI_LATEST_VERSION" ]; then

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -82,7 +82,7 @@ workflows:
               parameters:
                 executor: [python, base]
                 # Emtpy string will use latest version, otherwise testing random recent specific versions
-                cli-version: ["", "3.20.5", "3.20.4", "3.20.3"]
+                cli-version: ["", "3.20.5", "3.20.3", "3.20.2", "3.20.0"]
           filters: *filters
       - integration-test-deploy-setup:
           context: [CPE-OIDC]

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,8 +49,6 @@ jobs:
             if [ -n "$EBCLI_VERSION" ] && [ -n "$EBCLI_INPUT_VERSION" ] && [ -n "$EBCLI_LATEST_VERSION" ]; then
               if [ "$EBCLI_VERSION" == "$EBCLI_INPUT_VERSION" ]; then
                 echo "CLI version matches expected version."
-              elif [ "$EBCLI_VERSION" == "$EBCLI_LATEST_VERSION" ]; then
-                echo "CLI version matches the expected latest version."
               else
                 echo "Error: CLI version does not match expected version." >&2
                 exit 1

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -42,7 +42,7 @@ jobs:
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"
 
             # Checks if the installed version matches the expected version
-            if [ ! -z "$EBCLI_VERSION" ] && [ ! -z "$EBCLI_INPUT_VERSION" ] && [ ! -z "$EBCLI_LATEST_VERSION" ]; then
+            if [ -n "$EBCLI_VERSION" ] && [ -n "$EBCLI_INPUT_VERSION" ] && [ -n "$EBCLI_LATEST_VERSION" ]; then
               if [ "$EBCLI_VERSION" == "$EBCLI_INPUT_VERSION" ]; then
                 echo "CLI version matches expected version."
               elsif [ "$EBCLI_VERSION" == "$EBCLI_LATEST_VERSION" ]; then

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -17,8 +17,8 @@ jobs:
         default:
       cli-version:
         type: string
-        default:
-    executor: <<parameters.executor>>
+        default: << parameters.cli-version >>
+    executor: << parameters.executor >>
     steps:
       - checkout
       #- aws-cli/setup:
@@ -30,13 +30,11 @@ jobs:
             command -v eb >/dev/null 2>&1 || { echo >&2 "EB cli failed to install or persist to the path"; exit 1; }
       - run:
           name: Test app version
-          environment:
-            EBCLI_INPUT_VERSION: << parameters.cli-version >> 
           command: |
             echo "Checking CLI version..."
-            EBCLI_VERSION=$(eb --version)
+            EBCLI_VERSION=$(EB_CLI_VERSION=$(eb --version | awk '{print $3}'))
             # Uses python to isolate the latest ebcli version number from the pypi json.
-            EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")"
+            EBCLI_LATEST_VERSION=$(python3 -c "import json, urllib.request; print(json.load(urllib.request.urlopen('https://pypi.org/pypi/awsebcli/json'))['info']['version'])")""
             echo "Elastic Beanstalk CLI version: $EBCLI_VERSION"
             echo "Expected CLI version: $EBCLI_INPUT_VERSION"
             echo "Latest CLI version: $EBCLI_LATEST_VERSION"

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,7 +1,15 @@
 description: >
   Install and authenticate with the Elastic Beanstalk CLI.
   You must have your AWS auth environment variables set for ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"].
+
+parameters:
+  cli-version:
+    description: The version of the Elastic Beanstalc CLI that you wish to install. Defaults to latest.
+    type: string
+    default: ""
 steps:
   - run:
       name: Setting Up Elastic Beanstalk CLI
+      environment:
+        EBCLI_VERSION: << parameters.cli-version >>
       command: <<include(scripts/install-setup.sh)>>

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -1,7 +1,6 @@
 description: >
   Install and authenticate with the Elastic Beanstalk CLI.
   You must have your AWS auth environment variables set for ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_DEFAULT_REGION"].
-
 parameters:
   cli-version:
     description: The version of the Elastic Beanstalc CLI that you wish to install. Defaults to latest.

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -6,7 +6,7 @@ parameters:
   cli-version:
     description: The version of the Elastic Beanstalc CLI that you wish to install. Defaults to latest.
     type: string
-    default: ""
+    default:
 steps:
   - run:
       name: Setting Up Elastic Beanstalk CLI

--- a/src/commands/setup.yml
+++ b/src/commands/setup.yml
@@ -6,7 +6,7 @@ parameters:
   cli-version:
     description: The version of the Elastic Beanstalc CLI that you wish to install. Defaults to latest.
     type: string
-    default:
+    default: ""
 steps:
   - run:
       name: Setting Up Elastic Beanstalk CLI

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -27,7 +27,7 @@ SetupPipx() {
 
 
 InstallEBCLI() {
-    EBCLI_VERSION=$(eval echo "${EBCLI_VERSION}")
+    EBCLI_INPUT_VERSION=$(eval echo "${EBCLI_INPUT_VERSION}")
     if uname -a | grep Darwin > /dev/null 2>&1; then
         cd /tmp || { echo "Not able to access /tmp"; return; }
         git clone https://github.com/aws/aws-elastic-beanstalk-cli-setup.git
@@ -47,8 +47,8 @@ InstallEBCLI() {
         fi
     fi
     # If the version environment variable is set, install that version. Else install latest.
-    if [ -n "$EBCLI_VERSION" ]; then
-        pipx install awsebcli=="${EBCLI_VERSION}"
+    if [ -n "$EBCLI_INPUT_VERSION" ]; then
+        pipx install awsebcli=="${EBCLI_INPUT_VERSION}"
         echo "Complete"
     else
         pipx install awsebcli

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -46,7 +46,7 @@ InstallEBCLI() {
         fi
     fi
     # If the version environment variable is set, install that version. Else install latest.
-    if [ ! -z "$EBCLI_VERSION" ]; then
+    if [ -n "$EBCLI_VERSION" ]; then
         pipx install awsebcli --version "${EBCLI_VERSION}"
         echo "Complete"
     else

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -45,7 +45,7 @@ InstallEBCLI() {
             SetupPython
         fi
     fi
-    # If the version environment variable is set, install that version. else install latest.
+    # If the version environment variable is set, install that version. Else install latest.
     if [ ! -z "$EBCLI_VERSION" ]; then
         pipx install awsebcli --version "${EBCLI_VERSION}"
         echo "Complete"

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -46,7 +46,7 @@ InstallEBCLI() {
             SetupPython
         fi
     fi
-    # If the version environment variable is set, install that version. Else install latest.
+    # If the input version environment variable is set, install that version. Else install latest.
     if [ -n "$EBCLI_INPUT_VERSION" ]; then
         pipx install awsebcli=="${EBCLI_INPUT_VERSION}"
         echo "Complete"
@@ -76,6 +76,6 @@ CheckAWSEnvVars() {
 # View src/tests for more information.
 TEST_ENV="bats-core"
 if [ "${0#*"$TEST_ENV"}" == "$0" ]; then
-    #CheckAWSEnvVars
+    CheckAWSEnvVars
     InstallEBCLI
 fi

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -48,7 +48,7 @@ InstallEBCLI() {
     fi
     # If the version environment variable is set, install that version. Else install latest.
     if [ -n "$EBCLI_VERSION" ]; then
-        pipx install awsebcli --version "${EBCLI_VERSION}"
+        pipx install awsebcli=="${EBCLI_VERSION}"
         echo "Complete"
     else
         pipx install awsebcli

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -75,6 +75,6 @@ CheckAWSEnvVars() {
 # View src/tests for more information.
 TEST_ENV="bats-core"
 if [ "${0#*"$TEST_ENV"}" == "$0" ]; then
-    CheckAWSEnvVars
+    #CheckAWSEnvVars
     InstallEBCLI
 fi

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -27,6 +27,7 @@ SetupPipx() {
 
 
 InstallEBCLI() {
+    EBCLI_VERSION=$(eval echo "${EBCLI_VERSION}")
     if uname -a | grep Darwin > /dev/null 2>&1; then
         cd /tmp || { echo "Not able to access /tmp"; return; }
         git clone https://github.com/aws/aws-elastic-beanstalk-cli-setup.git

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -4,7 +4,7 @@ if [[ $EUID == 0 ]]; then export SUDO=""; else # Check if we are root
 fi
 
 SetupPython() {
-    # setups python3
+    # Sets up python3
     $SUDO apt-get -qq -y install python3-dev
     SetupPipx
 }
@@ -18,8 +18,8 @@ SetupPipx() {
         $SUDO apt-get install -qq -y python3-setuptools
         curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3
     fi
-    # install venv with system for pipx
-    # by using pipx we dont have to worry about activating the virtualenv before using eb
+    # Install venv with system for pipx
+    # By using pipx we dont have to worry about activating the virtualenv before using eb
     $SUDO apt-get -qq -y install python3-venv
     pip install pipx
 }
@@ -35,7 +35,7 @@ InstallEBCLI() {
         return $?
     elif uname -a | grep Linux > /dev/null 2>&1; then
         $SUDO apt-get -qq update > /dev/null
-        # these are the system level deps for the ebcli
+        # These are the system level deps for the ebcli
         $SUDO apt-get -qq -y install build-essential zlib1g-dev libssl-dev libncurses-dev libffi-dev libsqlite3-dev libreadline-dev libbz2-dev
         if [ "$(which python3 | tail -1)" ]; then
             echo "Python3 env found"
@@ -45,8 +45,14 @@ InstallEBCLI() {
             SetupPython
         fi
     fi
+    # If the version environment variable is set, install that version. else install latest.
+    if [ ! -z "$EBCLI_VERSION" ]; then
+        pipx install awsebcli --version "${EBCLI_VERSION}"
+        echo "Complete"
+    else
         pipx install awsebcli
         echo "Complete"
+    fi
 }
 
 CheckAWSEnvVars() {


### PR DESCRIPTION
Added a cli-version parameter to EB setup so that it doesn't always default to the latest version. Gives the user flexibility to install whatever version of awsebcli, as well as allows the user to maneuver around any versions that are buggy or unsupported on CircleCI. Also added comprehensive tests to make sure that this feature works.