### PR TITLE
feat: add deploy markers integration to deploy job

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  aws-cli: circleci/aws-cli@4.0
+  aws-cli: circleci/aws-cli@5.4.1
   orb-tools: circleci/orb-tools@12.0
   aws-elastic-beanstalk: {}
 
@@ -90,8 +90,8 @@ workflows:
           matrix:
             parameters:
               executor: [python, base]
-              # Emtpy string will use latest version, otherwise testing random recent versions
-              version: ["", "3.20.5", "3.20.3", "3.20.2", "3.20.0"]
+              # Empty string will use latest version, otherwise testing recent pinned versions
+              version: ["", "3.27.1", "3.27", "3.26", "3.25.3"]
           filters: *filters
       - integration-test-deploy-setup:
           context: [CPE-OIDC]
@@ -114,6 +114,7 @@ workflows:
           application_name: sample_app
           label: test-label
           app_dir: ./sample_app
+          deploy_markers_mode: OFF
           requires:
             - integration-test-deploy-setup
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -114,7 +114,8 @@ workflows:
           application_name: sample_app
           label: test-label
           app_dir: ./sample_app
-          deploy_markers_mode: OFF
+          deploy_markers_mode: PLAN_AND_UPDATE
+          deploy_markers_deploy_name: test-deploy
           requires:
             - integration-test-deploy-setup
           filters: *filters

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -7,3 +7,6 @@ display:
   home_url: https://aws.amazon.com/elasticbeanstalk/
   source_url: https://github.com/CircleCI-Public/aws-elastic-beanstalk-orb
 
+orbs:
+  deploys: circleci/deploys@1.0
+

--- a/src/examples/deploy_eb_with_deploy_markers.yml
+++ b/src/examples/deploy_eb_with_deploy_markers.yml
@@ -1,10 +1,10 @@
 description: >
   Deploy an Elastic Beanstalk application with CircleCI deploy markers.
   Four modes are available via the deploy_markers_mode parameter:
-    OFF           - no deploy markers (default)
+    OFF           - no deploy markers
     LOG           - log a deployment event after the EB deploy
     PLAN          - create a planned marker before the EB deploy; caller manages status updates
-    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed
+    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
 
 usage:
   version: 2.1

--- a/src/examples/deploy_eb_with_deploy_markers.yml
+++ b/src/examples/deploy_eb_with_deploy_markers.yml
@@ -1,0 +1,49 @@
+description: >
+  Deploy an Elastic Beanstalk application with CircleCI deploy markers.
+  Four modes are available via the deploy_markers_mode parameter:
+    OFF           - no deploy markers (default)
+    LOG           - log a deployment event after the EB deploy
+    PLAN          - create a planned marker before the EB deploy; caller manages status updates
+    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed
+
+usage:
+  version: 2.1
+
+  orbs:
+    aws-elastic-beanstalk: circleci/aws-elastic-beanstalk@2.0
+    aws-cli: circleci/aws-cli@5.4
+
+  workflows:
+    deploy:
+      jobs:
+        # LOG mode — log a deployment event after the EB deploy completes
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-log
+            application_name: my-app
+            environment_name: my-app-prod
+            deploy_markers_mode: LOG
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-plan
+            application_name: my-app
+            environment_name: my-app-prod
+            deploy_markers_mode: PLAN
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb (default)
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-full
+            application_name: my-app
+            environment_name: my-app-prod
+            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ description: >
 parameters:
   tag:
     type: string
-    default: "2023.05"
+    default: "2026.04"
     description: >
       Select any of the available tags here: https://circleci.com/developer/images/image/cimg/aws.
   resource_class:

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -48,10 +48,10 @@ parameters:
   deploy_markers_mode:
     description: >
       Controls CircleCI deploy marker integration via the deploys orb.
-      OFF: no deploy markers are created (default).
+      OFF: no deploy markers are created.
       LOG: logs a deployment event after the EB deploy completes.
       PLAN: creates a planned deployment marker before the EB deploy; status updates are left to the caller.
-      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after.
+      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after (default).
     type: enum
     enum: [OFF, LOG, PLAN, PLAN_AND_UPDATE]
     default: PLAN_AND_UPDATE

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -45,6 +45,34 @@ parameters:
       The authentication method used to access your AWS account. Import the aws-cli orb in your config and
       provide the aws-cli/setup command to authenticate with your preferred method. View examples for more information.
     type: steps
+  deploy_markers_mode:
+    description: >
+      Controls CircleCI deploy marker integration via the deploys orb.
+      OFF: no deploy markers are created (default).
+      LOG: logs a deployment event after the EB deploy completes.
+      PLAN: creates a planned deployment marker before the EB deploy; status updates are left to the caller.
+      PLAN_AND_UPDATE: full lifecycle — plan before deploy, mark as running, then set SUCCESS or FAILED after.
+    type: enum
+    enum: [OFF, LOG, PLAN, PLAN_AND_UPDATE]
+    default: PLAN_AND_UPDATE
+  deploy_markers_deploy_name:
+    description: >
+      Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
+      Must be unique if planning multiple deployments in the same workflow.
+    type: string
+    default: "deploy"
+  deploy_markers_namespace:
+    description: >
+      Namespace of the deployment shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to 'default' if not set.
+    type: string
+    default: ""
+  deploy_markers_target_version:
+    description: >
+      Version identifier shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the short commit SHA if not set.
+    type: string
+    default: ""
 
 executor: << parameters.executor >>
 
@@ -52,6 +80,26 @@ steps:
   - checkout
   - steps: << parameters.auth >>
   - setup
+  - when:
+      condition:
+        or:
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN"]
+          - equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/plan:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            component_name: << parameters.application_name >>
+            environment_name: << parameters.environment_name >>
+            namespace: << parameters.deploy_markers_namespace >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: RUNNING
+            when: always
   - run:
       name: EB Deploy
       working_directory: << parameters.app_dir >>
@@ -64,3 +112,24 @@ steps:
         ORB_STR_DESCRIPTION: << parameters.description >>
         ORB_STR_PROFILE_NAME: << parameters.profile_name >>
       command: << include(scripts/deploy.sh) >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "LOG"]
+      steps:
+        - deploys/log:
+            component_name: << parameters.application_name >>
+            environment_name: << parameters.environment_name >>
+            namespace: << parameters.deploy_markers_namespace >>
+            target_version: << parameters.deploy_markers_target_version >>
+  - when:
+      condition:
+        equal: [<< parameters.deploy_markers_mode >>, "PLAN_AND_UPDATE"]
+      steps:
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: SUCCESS
+            when: on_success
+        - deploys/update_status:
+            deploy_name: << parameters.deploy_markers_deploy_name >>
+            status: FAILED
+            when: on_fail

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -59,8 +59,9 @@ parameters:
     description: >
       Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
       Must be unique if planning multiple deployments in the same workflow.
+      Defaults to the workflow job ID, which is unique per job run.
     type: string
-    default: "deploy"
+    default: ${CIRCLE_WORKFLOW_JOB_ID}
   deploy_markers_namespace:
     description: >
       Namespace of the deployment shown in the CircleCI Deploys UI.

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -16,12 +16,13 @@ SetupPipx() {
         echo "pip not found"
         $SUDO apt-get update
         $SUDO apt-get install -qq -y python3-setuptools
-        curl https://bootstrap.pypa.io/pip/3.5/get-pip.py | python3
+        curl https://bootstrap.pypa.io/get-pip.py | python3
     fi
     # Install venv with system for pipx
     # By using pipx we dont have to worry about activating the virtualenv before using eb
     $SUDO apt-get -qq -y install python3-venv
-    pip install pipx
+    # --break-system-packages is required on Ubuntu 22.04+ (PEP 668); fall back for older pip
+    pip install pipx --break-system-packages 2>/dev/null || pip install pipx
 }
 
 

--- a/src/scripts/install-setup.sh
+++ b/src/scripts/install-setup.sh
@@ -10,19 +10,18 @@ SetupPython() {
 }
 
 SetupPipx() {
-    if [ "$(which pip | tail -1)" ]; then
-        echo "pip found"
-    else
-        echo "pip not found"
-        $SUDO apt-get update
-        $SUDO apt-get install -qq -y python3-setuptools
-        curl https://bootstrap.pypa.io/get-pip.py | python3
-    fi
-    # Install venv with system for pipx
-    # By using pipx we dont have to worry about activating the virtualenv before using eb
     $SUDO apt-get -qq -y install python3-venv
-    # --break-system-packages is required on Ubuntu 22.04+ (PEP 668); fall back for older pip
-    pip install pipx --break-system-packages 2>/dev/null || pip install pipx
+    if ! command -v pipx > /dev/null 2>&1; then
+        # Prefer apt (Ubuntu 23.04+) to avoid PEP 668 externally-managed-environment errors
+        if ! $SUDO apt-get -qq -y install pipx 2>/dev/null; then
+            # Fallback for older Ubuntu where pipx is not in apt
+            if ! command -v pip > /dev/null 2>&1; then
+                echo "pip not found, installing via apt"
+                $SUDO apt-get install -qq -y python3-pip
+            fi
+            pip install pipx
+        fi
+    fi
 }
 
 


### PR DESCRIPTION
Adds a deploy_markers_mode parameter (OFF/LOG/PLAN/PLAN_AND_UPDATE) to the deploy job, wiring in the circleci/deploys orb for full lifecycle tracking. All new parameters default so existing configs require no changes.

Integration tests fail because it is running on my fork and not CircleCI-Public