### PR TITLE
Default deploy name to CIRCLE_WORKFLOW_JOB_ID

### DIFF
--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -58,9 +58,9 @@ parameters:
   deploy_markers_deploy_name:
     description: >
       Unique identifier for this deployment within the workflow. Used by PLAN and PLAN_AND_UPDATE modes.
-      Must be unique if planning multiple deployments in the same workflow.
+      Must be unique if planning multiple deployments in the same workflow. Defaults to the CircleCI workflow job ID.
     type: string
-    default: "deploy"
+    default: "${CIRCLE_WORKFLOW_JOB_ID}"
   deploy_markers_namespace:
     description: >
       Namespace of the deployment shown in the CircleCI Deploys UI.


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:
Default `deploy_markers_deploy_name` to `${CIRCLE_WORKFLOW_JOB_ID}` instead of the static string `"deploy"`. Update the parameter description to reflect the new default.

## Motivation:
Using a static default deploy name means multiple deployments in the same workflow would share the same identifier, violating the uniqueness requirement. Defaulting to the workflow job ID ensures uniqueness automatically without requiring callers to set this parameter explicitly.

**Closes Issues:**
- N/A

## Checklist:
- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

Made with [Cursor](https://cursor.com)