### PR TITLE
expose deploys params and expand configuration examples

### DIFF
--- a/src/examples/deploy_eb_application_to_env_with_oidc.yml
+++ b/src/examples/deploy_eb_application_to_env_with_oidc.yml
@@ -3,6 +3,9 @@ description: |
   Import the aws-cli orb and authenticate using the aws-cli/setup command with a valid role_arn for OIDC authentication.
   This example shows how a Node.JS application may be tested and then deployed in a realistic CI environment, using both the Node orb and AWS Elastic Beanstalk orb.
   This assumes the EB environment already exists and is awaiting deployments.
+  Deploy markers are enabled by default (PLAN_AND_UPDATE mode): a CircleCI deploy marker is created before the deploy,
+  marked as running when it starts, and automatically updated to success or failed when the job completes.
+  The target version defaults to the short commit SHA and is shown in the CircleCI Deploys UI.
 
 usage:
   version: 2.1

--- a/src/examples/deploy_eb_with_deploy_markers.yml
+++ b/src/examples/deploy_eb_with_deploy_markers.yml
@@ -7,8 +7,7 @@ description: >
   This example shows the optional parameters available to customize deploy marker behavior:
     deploy_markers_target_version   - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
     deploy_markers_deploy_name      - unique identifier for this deployment; defaults to the workflow job ID,
-                                      which is already unique per execution, but can be set explicitly for
-                                      a more readable name in the CircleCI Deploys UI
+                                      which is already unique per execution, but can be set explicitly
     deploy_markers_component_name   - component label shown in the CircleCI Deploys UI (defaults to application_name)
     deploy_markers_environment_name - environment label shown in the CircleCI Deploys UI (defaults to 'default')
     deploy_markers_mode             - override the default PLAN_AND_UPDATE mode when needed:

--- a/src/examples/deploy_eb_with_deploy_markers.yml
+++ b/src/examples/deploy_eb_with_deploy_markers.yml
@@ -1,10 +1,20 @@
 description: >
-  Deploy an Elastic Beanstalk application with CircleCI deploy markers.
-  Four modes are available via the deploy_markers_mode parameter:
-    OFF           - no deploy markers
-    LOG           - log a deployment event after the EB deploy
-    PLAN          - create a planned marker before the EB deploy; caller manages status updates
-    PLAN_AND_UPDATE - full lifecycle: plan → running → success/failed (default)
+  Deploy an Elastic Beanstalk application with CircleCI deploy markers (enabled by default via PLAN_AND_UPDATE mode).
+  The default PLAN_AND_UPDATE lifecycle creates a planned marker before the deploy, marks it as
+  running when the deploy starts, and automatically sets it to success or failed when the job
+  completes — no extra configuration required.
+
+  This example shows the optional parameters available to customize deploy marker behavior:
+    deploy_markers_target_version   - version label shown in the CircleCI Deploys UI (defaults to short commit SHA)
+    deploy_markers_deploy_name      - unique identifier for this deployment; defaults to the workflow job ID,
+                                      which is already unique per execution, but can be set explicitly for
+                                      a more readable name in the CircleCI Deploys UI
+    deploy_markers_component_name   - component label shown in the CircleCI Deploys UI (defaults to application_name)
+    deploy_markers_environment_name - environment label shown in the CircleCI Deploys UI (defaults to 'default')
+    deploy_markers_mode             - override the default PLAN_AND_UPDATE mode when needed:
+                                        LOG             - log a deployment event after the EB deploy (no planned marker)
+                                        PLAN            - create a planned marker before deploy; caller manages status updates
+                                        OFF             - disable deploy markers entirely
 
 usage:
   version: 2.1
@@ -16,34 +26,62 @@ usage:
   workflows:
     deploy:
       jobs:
-        # LOG mode — log a deployment event after the EB deploy completes
+        # Default usage — deploy markers are on (PLAN_AND_UPDATE), target version defaults to short commit SHA
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-app
+            application_name: my-app
+            environment_name: my-app-prod
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # Multiple deploys in the same workflow — optionally set deploy_markers_deploy_name for clearer identification
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-app-staging
+            application_name: my-app
+            environment_name: my-app-staging
+            deploy_markers_target_version: '${CIRCLE_SHA1}'
+            deploy_markers_deploy_name: deploy-my-app-staging
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-app-prod
+            application_name: my-app
+            environment_name: my-app-prod
+            deploy_markers_target_version: '${CIRCLE_SHA1}'
+            deploy_markers_deploy_name: deploy-my-app-prod
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # Custom component and environment names — useful when the EB names differ from how they appear in the CircleCI Deploys UI
+        - aws-elastic-beanstalk/deploy:
+            name: deploy-custom-labels
+            application_name: my-app-v2-internal
+            environment_name: my-app-v2-internal-prod-us-east-1
+            deploy_markers_component_name: my-app
+            deploy_markers_environment_name: production
+            auth:
+              - aws-cli/setup:
+                  role_arn: ${AWS_ROLE_ARN}
+
+        # LOG mode — records a deployment event after the deploy completes; no planned marker is created
         - aws-elastic-beanstalk/deploy:
             name: deploy-log
             application_name: my-app
             environment_name: my-app-prod
             deploy_markers_mode: LOG
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
             auth:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}
 
-        # PLAN mode — create a planned marker before deploy; status updates are left to the caller
+        # Opting out — disable deploy markers with deploy_markers_mode: OFF
         - aws-elastic-beanstalk/deploy:
-            name: deploy-plan
+            name: deploy-no-markers
             application_name: my-app
             environment_name: my-app-prod
-            deploy_markers_mode: PLAN
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
-            auth:
-              - aws-cli/setup:
-                  role_arn: ${AWS_ROLE_ARN}
-
-        # PLAN_AND_UPDATE mode — full lifecycle managed by the orb (default)
-        - aws-elastic-beanstalk/deploy:
-            name: deploy-full
-            application_name: my-app
-            environment_name: my-app-prod
-            deploy_markers_target_version: ${CIRCLE_SHA1:0:7}
+            deploy_markers_mode: OFF
             auth:
               - aws-cli/setup:
                   role_arn: ${AWS_ROLE_ARN}

--- a/src/jobs/deploy.yml
+++ b/src/jobs/deploy.yml
@@ -61,16 +61,28 @@ parameters:
       Must be unique if planning multiple deployments in the same workflow. Defaults to the CircleCI workflow job ID.
     type: string
     default: "${CIRCLE_WORKFLOW_JOB_ID}"
+  deploy_markers_component_name:
+    description: >
+      Component name shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. When left empty, falls back to the application_name parameter.
+    type: string
+    default: ""
+  deploy_markers_environment_name:
+    description: >
+      Environment name shown in the CircleCI Deploys UI.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to 'default'.
+    type: string
+    default: "default"
   deploy_markers_namespace:
     description: >
       Namespace of the deployment shown in the CircleCI Deploys UI.
-      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to 'default' if not set.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. When left empty, the deploys orb uses 'default'.
     type: string
     default: ""
   deploy_markers_target_version:
     description: >
       Version identifier shown in the CircleCI Deploys UI.
-      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. Defaults to the short commit SHA if not set.
+      Used by LOG, PLAN, and PLAN_AND_UPDATE modes. When left empty, the deploys orb uses the short commit SHA.
     type: string
     default: ""
 
@@ -88,8 +100,8 @@ steps:
       steps:
         - deploys/plan:
             deploy_name: << parameters.deploy_markers_deploy_name >>
-            component_name: << parameters.application_name >>
-            environment_name: << parameters.environment_name >>
+            component_name: <<# parameters.deploy_markers_component_name >><< parameters.deploy_markers_component_name >><</ parameters.deploy_markers_component_name >><<^ parameters.deploy_markers_component_name >><< parameters.application_name >><</ parameters.deploy_markers_component_name >>
+            environment_name: << parameters.deploy_markers_environment_name >>
             namespace: << parameters.deploy_markers_namespace >>
             target_version: << parameters.deploy_markers_target_version >>
   - when:
@@ -117,8 +129,8 @@ steps:
         equal: [<< parameters.deploy_markers_mode >>, "LOG"]
       steps:
         - deploys/log:
-            component_name: << parameters.application_name >>
-            environment_name: << parameters.environment_name >>
+            component_name: <<# parameters.deploy_markers_component_name >><< parameters.deploy_markers_component_name >><</ parameters.deploy_markers_component_name >><<^ parameters.deploy_markers_component_name >><< parameters.application_name >><</ parameters.deploy_markers_component_name >>
+            environment_name: << parameters.deploy_markers_environment_name >>
             namespace: << parameters.deploy_markers_namespace >>
             target_version: << parameters.deploy_markers_target_version >>
   - when:


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [x] Patch

## Description:

- Add deploy markers default-on notice to `deploy_eb_application_to_env_with_oidc` description
- Rewrite `deploy_eb_with_deploy_markers` example to focus on optional configuration knobs rather than listing all modes as parallel examples:
  - Default usage block shows zero deploy-marker params needed
  - Multi-deploy block demonstrates `deploy_markers_deploy_name` (optional, defaults to workflow job ID)
  - New block showcases `deploy_markers_component_name` and `deploy_markers_environment_name` for custom Deploys UI labels
  - LOG mode block and opt-out (OFF) block
- Add `deploy_markers_component_name` and `deploy_markers_environment_name` parameters to the deploy job
- Use `default: "default"` for `deploy_markers_environment_name` instead of a Mustache fallback expression
- Clarify parameter descriptions to distinguish where fallback behavior is implemented (this job vs. the deploys orb)

## Motivation:

Users reading the examples should immediately understand that deploy markers are on by default and require no extra configuration. The deploy-markers-specific example should serve as a guide to the optional knobs, not a mode reference. Modelled after [CircleCI-Public/aws-ecs-orb#250](https://github.com/CircleCI-Public/aws-ecs-orb/pull/250).

**Closes Issues:**
- N/A

## Checklist:

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.

Made with [Cursor](https://cursor.com)